### PR TITLE
feat: add versions to adr002, 003

### DIFF
--- a/docs/hercules/adr002-authorization-discovery/README.md
+++ b/docs/hercules/adr002-authorization-discovery/README.md
@@ -1,6 +1,6 @@
 ---
-id: fx_adr002
-title: ADR 002 – Cross-Company Authorization and Discovery
+id: fx_adr002_0.2.0
+title: ADR 002 – Cross-Company Authorization and Discovery - version 0.2.0
 date: 2025-08-21
 tags: [architecture_decision_records, network_adr, security]
 ---
@@ -11,18 +11,34 @@ Cross-Company data transfer requires discovery and fine grained authorization fo
 there is a requirement to agree on the terms & conditions of data access. Such data offers must be discoverable,
 understandable and executable by each dataspace participant, thus based on a single and common description language.
 
-### Solution description
+### Solution description **(normative)**
 
-**All Data Providers who provision data across participant boundaries MUST expose it via Dataspace Protocol [1] and accept
-STS-Tokens (see [ADR 003](../adr003-authentication/README.md)) as access tokens.**
+All Data Providers who provision data across participant boundaries MUST expose it via Dataspace Protocol 2025-1 [1] 
+and accept STS-Tokens (see [ADR 003, 0.2.0](../adr003-authentication/README.md)) as access tokens.
 
-Factory-X will create specializations of the DSP with regards to terms and means of data exchange.
+For exposure of HTTP-based transfers, Data Providers MUST set the following properties:
+- A Provider MUST set the relevant `Distribution` objects' `"format":"HttpData-PULL"` in the `Catalog` response.
+- A Consumer MUST send a `TransferRequestMessage` with `"format":"HttpData-PULL"`.
+- A Provider MUST send a `TransferStartMessage` with sufficient information in the `dataAddress` property so
+that an HTTP request to the `endpoint` may succeed. The `endpointType` property MUST be
+`https://w3id.org/idsa/v4.1/HTTP`. The following `endpointProperties` are to be added to the object as specified in the
+table below:
+
+| Name                                             |          | description                                                                                                                                                   |
+|--------------------------------------------------|----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `https://w3id.org/edc/v0.0.1/ns/authorization`   | REQUIRED | The access token to access data. To be included in the `Authorization` header.                                                                                |
+| `https://w3id.org/edc/v0.0.1/ns/authType`        | REQUIRED | Prefix for the `Authorization` header's content.                                                                                                              |
+| `https://w3id.org/tractusx/auth/refreshEndpoint` | REQUIRED | Endpoint to refresh the access token using the `refreshToken`. It behaves as defined in [RFC6749](#rfc-6749) section 6 using an STS-token for authentication. |
+| `https://w3id.org/tractusx/auth/refreshToken`    | REQUIRED | The refresh token to present to the `refreshEndpoint` in conjunction with the old access token.                                                               |
+| `https://w3id.org/tractusx/auth/expiresIn`       | REQUIRED | Time to live for the access token after issuance.                                                                                                             |
+
+### Context
 
 The Dataspace Protocol (DSP) defines a set of API-endpoints, processes, and messages that allow and regulate discovery
 and negotiation processes for a data exchange between Data Providers and Consumers.
 
 Following the DSP definitions, a data provider creates a “Data Offer” for the data it wishes to share with consumers.
-The offer includes a binding to a set of contractual terms the specify how the data may be used. Moreover, the DSP
+The offer includes a binding to a set of contractual terms that specify how the data may be used. Moreover, the DSP
 API-endpoints can be used by the provider to expose the data offers and advertise them to potential data consumers in a
 discoverable manner.
 
@@ -32,7 +48,7 @@ offer.
 
 ### Expected business consequences
 
-The DSP provides a straightforward and well defined way for data providers to offer their data under specified
+The DSP provides a straightforward and well-defined way for data providers to offer their data under specified
 conditions to potential consumers. This process will introduce some consequences (in both directions) for dataspace
 participants using the DSP:
 
@@ -50,5 +66,7 @@ consumer what proof of identity to present.
 
 AAS Discovery + ABAC: Not feasible for Non-AAS-Resources, no consideration of terms of Data Exchange, unclear trust
 model and authentication mechanisms
+
+### References
 
 [1] https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol

--- a/docs/hercules/adr003-authentication/README.md
+++ b/docs/hercules/adr003-authentication/README.md
@@ -1,6 +1,6 @@
 ---
-id: fx_adr003
-title: ADR 003 – Authentication for Dataspace
+id: fx_adr003_0.2.0
+title: ADR 003 – Authentication for Dataspaces, version 0.2.0
 date: 2025-08-21
 tags: [architecture_decision_records, network_adr, security]
 ---
@@ -14,15 +14,20 @@ R2) integrate in ecosystems with multiple independent sources of trust,
 R3) access, parse and understand claims made about a participant based on an established common set of attributes (such
 as roles).
 
-### Solution description
+### Solution description (normative)
 
-S1) identification via DIDs, public key resolution via DID documents and did:web [1,2]
+Every participant MUST claim a did according to the did:web method [1,2]. 
+Every participant MUST expose a did document indicating public keys and services according to Decentralized Claims
+Protocol v1.0 [4] chapters 4.3.3, 5.2, 5.4.3 and 6.2.
+Every participant MUST present its credentials according to Decentralized Claims Protocol's Verifiable Presentation
+Protocol in the profile `vc11-sl2021/jwt`.
 
-S2) leave it up to each participant what issuers to trust for what claims.
+### Context
 
-S3) Design a common set of Factory-X credential claims to be exchanged, extending the W3C Verifiable Credential (VC)
-Standard [3], exchanged via the Verifiable Presentation Protocol that is part of the Decentralized Claims Protocol [4].
-
+Each participant is free to trust the Verifiable Credential issuers of their choice. The protocol stack unifies the
+possibility of peer-to-peer relationships and the integration of a third-party source of trust. This ADR leaves open the
+design of a common set of Factory-X credential claims to be exchanged, extending the W3C Verifiable Credential (VC)
+Standard [3]
 
 ### Expected business consequences
 

--- a/docs/hercules/adr003-authentication/README.md
+++ b/docs/hercules/adr003-authentication/README.md
@@ -17,8 +17,10 @@ as roles).
 ### Solution description (normative)
 
 Every participant MUST claim a did according to the did:web method [1,2]. 
+
 Every participant MUST expose a did document indicating public keys and services according to Decentralized Claims
 Protocol v1.0 [4] chapters 4.3.3, 5.2, 5.4.3 and 6.2.
+
 Every participant MUST present its credentials according to Decentralized Claims Protocol's Verifiable Presentation
 Protocol in the profile `vc11-sl2021/jwt`.
 


### PR DESCRIPTION
## WHAT

clarifies the versions of the auth-relevant ADRs and introduces versioning for themselves.

## WHY

Until now, the referenced specs' versions were implicit in the links.
