### PR TITLE
feat: improved dependabot and blog spelling fix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,29 @@
 # Please see the documentation for all configuration options:
 # https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
+
+
 version: 2
 updates:
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "npm"
+    directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
+    groups:
+      react-stack:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
+        applies-to: "version-updates"
+
+      all-minor-patch:
+        patterns:
+          - "*"
+        applies-to: "version-updates"
+               update-types:
+          - "minor"
+
+
+

--- a/blog/2025-12-19-release-2025-12/release-notes-2025-12.md
+++ b/blog/2025-12-19-release-2025-12/release-notes-2025-12.md
@@ -1,6 +1,6 @@
 ---
 slug: Release 2025-12
-title: Announcing Release 2025-1
+title: Announcing Release 2025-12
 authors: [ arnoweiss ]
 tags: [ architecture_decision_records, factory-x ]
 ---


### PR DESCRIPTION
## WHAT

Improved dependabot to group PRs

## WHY

Because they often depend on each other and  the first build (after the PR-merge) fails

## FURTHER NOTES
/