### PR TITLE
fix: link in release blog

### DIFF
--- a/blog/2025-12-19-release-2025-12/release-notes-2025-12.md
+++ b/blog/2025-12-19-release-2025-12/release-notes-2025-12.md
@@ -7,7 +7,7 @@ tags: [ architecture_decision_records, factory-x ]
 
 <!-- truncate -->
 
-This [set of webpages](http://localhost:3000/architecture-decisions/) specifies the first release of the Factory-X data ecosystem.
+This [set of webpages](https://factory-x-contributions.github.io/architecture-decisions/docs/hercules/adr002-authorization-discovery) specifies the first release of the Factory-X data ecosystem.
 
 ### On Releases
 


### PR DESCRIPTION
## WHAT

This is fixing a link in the release 2025-12 blog

## WHY

Good to find right hyperlinks in a blog 

## FURTHER NOTES