### PR TITLE
Added Use Case ADR 103 for Use Case Carbon Footprint Management

### DIFF
--- a/docs/hercules_use_case_adr/adr103-Carbon Footprint Management/adr103 - Reuse of Catena-X functionalities for PCF exchange.md
+++ b/docs/hercules_use_case_adr/adr103-Carbon Footprint Management/adr103 - Reuse of Catena-X functionalities for PCF exchange.md
@@ -22,11 +22,11 @@ tags: [architecture_decision_records, PCF, Catena-X, Tractus-X, reuse, API]
 
 - The partners MUST implement PCF exchange according to Catena-X CX-0136 "Use Case PCF" (v2.2.1) and its defined synchronous and/or asynchronous exchange patterns, including the "standardization triangle" requirements.
 
-- If asynchronous data exchange is used, the PCF Exchange API MUST be implemented as specified (HTTP GET for request, HTTP PUT for response) and MUST be called via a Catena‑X conform connector according to CX‑0018 “Dataspace Connectivity” / Factory-X adr008 & adr003 (not directly).
+- If asynchronous data exchange is used, the PCF Exchange API MUST be implemented as specified (HTTP GET for request, HTTP PUT for response) and MUST be called via a Catena‑X conform connector according to CX‑0018 “Dataspace Connectivity” / Factory-X adr 002 & adr003 (not directly).
 
-- If synchronous data exchange is used, the Data Provider MUST register the required submodel endpoint in the Digital Twin (e.g., idShort: "SynchronousPCFExchangeEndpoint") and the synchronous GET MUST be executed via a Catena‑X conform connector according to CX‑0018 “Dataspace Connectivity” / Factory-X adr008 & adr003 (DSP negotiation + Data Plane) and MUST NOT bypass this connector.
+- If synchronous data exchange is used, the Data Provider MUST register the required submodel endpoint in the Digital Twin (e.g., idShort: "SynchronousPCFExchangeEndpoint") according to CX-0002 "Digital Twins in Catena-X" / Factory-X adr008 & adr009, and the synchronous GET MUST be executed via a Catena-X conform connector according to CX-0018 "Dataspace Connectivity" / Factory-X adr002 & adr003 (DSP negotiation + Data Plane) and MUST NOT bypass this connector.
 
-- The partners MUST follow the additional Catena-X standards referenced as supporting standards in CX-0136 (e.g., Digital Twins, Dataspace Connectivity, SAMM), insofar as they are used by the PCF use case.
+- The partners MUST follow the additional Catena-X standards referenced as supporting standards in CX-0136 (e.g., CX-0002 "Digital Twins in Catena-X", CX-0018 "Dataspace Connectivity", CX-0003 "SAMM Aspect Meta Model"), insofar as they are used by the PCF use case.
 
 ## Data Models
 
@@ -38,5 +38,5 @@ tags: [architecture_decision_records, PCF, Catena-X, Tractus-X, reuse, API]
 
 ## Authentication and Authorization
 
-- Data sharing MUST follow the CX‑0136 conformance and proof‑of‑conformity requirements for Catena‑X participants, including that standardized OpenAPI specs and CX‑0018 “Dataspace Connectivity” / Factory-X adr008 & adr003 asset/contract structures MUST correspond to the described structure.
-- Where policies are used in the PCF exchange context, CX-0136 specifies required minimum policy elements (e.g., Membership, FrameworkAgreement, UsagePurpose) and references the Catena-X policy constraints standard that MUST be followed for providing/consuming data in Catena-X.
+- Data sharing MUST follow the CX‑0136 conformance and proof‑of‑conformity requirements for Catena‑X participants, including that standardized OpenAPI specs and CX‑0018 “Dataspace Connectivity” / Factory-X adr002 & adr003 asset/contract structures MUST correspond to the described structure.
+- Where policies are used in the PCF exchange context, CX-0136 specifies required minimum policy elements (e.g., Membership, FrameworkAgreement, UsagePurpose) and references the Catena-X policy constraints standard that MUST be followed for providing/consuming data in Catena-X. These policy elements are defined as Verifiable Credentials in CX-0050 "CX-Specific Credentials" and their enforcement rules are specified in CX-0152 "Policy Constraints for Data Exchange", both of which MUST be followed when exchanging PCF data with Catena-X-aligned partners.


### PR DESCRIPTION
## WHAT

Added Use Case ADR "adr103 - Reuse of Catena-X functionalities for PCF exchange" for Use Case Carbon Footprint Management

## WHY

This ADR provides normative guidance for implementing Product Carbon Footprint (PCF) data exchange in Factory-X by adopting Catena-X / Tractus-X PCF exchange specification ("standardization triangle": mandatory components, data models, APIs, registration/procedures).
The objective is interoperability with Catena-X-aligned partners and a verifiable conformance basis

Closes # <-- _insert Issue number if one exists_