### PR TITLE
feat: add ADR linting in CI

### DIFF
--- a/.github/workflows/lint-adrs.yaml
+++ b/.github/workflows/lint-adrs.yaml
@@ -1,0 +1,26 @@
+name: Lint ADRs
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'docs/**/adr*/**'
+
+jobs:
+  lint:
+    name: Validate ADR structure and frontmatter
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint ADRs
+        run: node scripts/lint-adrs.js

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "clear": "docusaurus clear",
     "serve": "docusaurus serve",
     "write-translations": "docusaurus write-translations",
-    "write-heading-ids": "docusaurus write-heading-ids"
+    "write-heading-ids": "docusaurus write-heading-ids",
+    "lint:adrs": "node scripts/lint-adrs.js"
   },
   "dependencies": {
     "@docusaurus/core": "3.9.2",

--- a/scripts/lint-adrs.js
+++ b/scripts/lint-adrs.js
@@ -1,0 +1,96 @@
+const fs = require('fs');
+const path = require('path');
+const matter = require('gray-matter');
+
+const DOCS_DIR = path.join(__dirname, '..', 'docs');
+const ADR_DIR_PATTERN = /^adr(\d+)-(.+)$/;
+const ADR_ID_PATTERN = /^fx_adr\w+$/;
+
+const errors = [];
+const adrNumbers = new Map(); // number -> directory path (for uniqueness check)
+
+function scan(directory) {
+  if (!fs.existsSync(directory)) return;
+
+  for (const item of fs.readdirSync(directory)) {
+    const fullPath = path.join(directory, item);
+    const stat = fs.statSync(fullPath);
+
+    if (!stat.isDirectory()) continue;
+
+    if (item.startsWith('adr')) {
+      lintADRDirectory(fullPath, item);
+    } else {
+      scan(fullPath);
+    }
+  }
+}
+
+function lintADRDirectory(dirPath, dirName) {
+  const rel = path.relative(path.join(__dirname, '..'), dirPath);
+
+  // Check directory name pattern
+  const dirMatch = ADR_DIR_PATTERN.exec(dirName);
+  if (!dirMatch) {
+    errors.push(`${rel}: Directory name must match pattern adrXXX-{slug} (e.g. adr002-my-topic)`);
+    return;
+  }
+
+  const adrNumber = dirMatch[1];
+
+  // Check uniqueness of ADR number
+  if (adrNumbers.has(adrNumber)) {
+    errors.push(`${rel}: Duplicate ADR number ${adrNumber} (already used by ${adrNumbers.get(adrNumber)})`);
+  } else {
+    adrNumbers.set(adrNumber, rel);
+  }
+
+  // Check README.md exists with exact casing
+  const files = fs.readdirSync(dirPath);
+  const readmeFile = files.find(f => f.toLowerCase() === 'readme.md');
+
+  if (!readmeFile) {
+    errors.push(`${rel}: Missing README.md`);
+    return;
+  }
+
+  if (readmeFile !== 'README.md') {
+    errors.push(`${rel}: Found '${readmeFile}' but expected exact name 'README.md'`);
+  }
+
+  // Validate frontmatter
+  const readmePath = path.join(dirPath, readmeFile);
+  const content = fs.readFileSync(readmePath, 'utf8');
+  let frontmatter;
+
+  try {
+    ({ data: frontmatter } = matter(content));
+  } catch (e) {
+    errors.push(`${rel}/README.md: Invalid frontmatter — ${e.message}`);
+    return;
+  }
+
+  if (!frontmatter.id) {
+    errors.push(`${rel}/README.md: Missing required frontmatter field 'id'`);
+  } else if (!ADR_ID_PATTERN.test(frontmatter.id)) {
+    errors.push(`${rel}/README.md: 'id' must match pattern fx_adrXXX (got '${frontmatter.id}')`);
+  }
+
+  if (!frontmatter.title) {
+    errors.push(`${rel}/README.md: Missing required frontmatter field 'title'`);
+  }
+}
+
+// Run
+scan(DOCS_DIR);
+
+if (errors.length > 0) {
+  console.error(`\nADR Lint: ${errors.length} error(s) found:\n`);
+  for (const err of errors) {
+    console.error(`  ✗ ${err}`);
+  }
+  console.error('');
+  process.exit(1);
+} else {
+  console.log('ADR Lint: All checks passed.');
+}


### PR DESCRIPTION
## Summary

- Add `scripts/lint-adrs.js` that validates ADR structure and frontmatter (`README.md` casing, required fields `id`/`title`, ID pattern, number uniqueness)
- Add GitHub Actions workflow that runs on PRs touching ADR files
- Add `npm run lint:adrs` script for local use

Closes #64

## Test plan

- [x] `node scripts/lint-adrs.js` passes on all existing ADRs
- [x] `npm run build` succeeds