### PR TITLE
feat: add impact analysis on hover in ADR Graph

### DIFF
--- a/src/components/ADRGraph/ADRGraph.js
+++ b/src/components/ADRGraph/ADRGraph.js
@@ -191,16 +191,6 @@ export default function ADRGraph() {
 
     const isDark = colorMode === 'dark';
 
-    // Compute connected node IDs for hover impact analysis
-    const connectedNodeIds = new Set();
-    if (hoveredNodeId) {
-      connectedNodeIds.add(hoveredNodeId);
-      for (const edge of filteredEdges) {
-        if (edge.source === hoveredNodeId) connectedNodeIds.add(edge.target);
-        if (edge.target === hoveredNodeId) connectedNodeIds.add(edge.source);
-      }
-    }
-
     const reactFlowNodes = filteredNodes.map((node) => {
       const { width, height } = getBubbleDimensions(node.referenceCount);
       const isHighlighted = searchTerm !== '' &&
@@ -209,8 +199,6 @@ export default function ADRGraph() {
 
       const colors = CATEGORY_COLORS[node.category] || CATEGORY_COLORS.network;
       const categoryColor = isDark ? colors.dark : colors.light;
-
-      const isDimmed = hoveredNodeId && !connectedNodeIds.has(node.id);
 
       // Build complete path with version prefix and baseUrl
       // Paths in JSON are like: /hercules_network_adr/adr002-...
@@ -249,7 +237,6 @@ export default function ADRGraph() {
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
-          opacity: isDimmed ? 0.2 : 1,
           transition: 'opacity 0.2s ease'
         }
       };
@@ -257,8 +244,6 @@ export default function ADRGraph() {
 
     const reactFlowEdges = filteredEdges.map((edge) => {
       const edgeColor = isDark ? '#6b8ec8' : '#4a7bc8';
-      const isConnectedEdge = hoveredNodeId && (edge.source === hoveredNodeId || edge.target === hoveredNodeId);
-      const isEdgeDimmed = hoveredNodeId && !isConnectedEdge;
 
       return {
         id: edge.id,
@@ -268,8 +253,7 @@ export default function ADRGraph() {
         animated: true,
         style: {
           stroke: edgeColor,
-          strokeWidth: isConnectedEdge ? 5 : 3,
-          opacity: isEdgeDimmed ? 0.1 : 1,
+          strokeWidth: 3,
           transition: 'opacity 0.2s ease, stroke-width 0.2s ease'
         },
         markerEnd: {
@@ -288,7 +272,41 @@ export default function ADRGraph() {
 
     setNodes(layoutedNodes);
     setEdges(layoutedEdges);
-  }, [graphData, filteredProjects, filteredCategories, searchTerm, colorMode, currentVersion, latestVersion, baseUrl, hoveredNodeId]);
+  }, [graphData, filteredProjects, filteredCategories, searchTerm, colorMode, currentVersion, latestVersion, baseUrl]);
+
+  // Hover impact analysis — lightweight style-only update, no layout recalculation
+  useEffect(() => {
+    if (!graphData.edges) return;
+
+    const connectedNodeIds = new Set();
+    if (hoveredNodeId) {
+      connectedNodeIds.add(hoveredNodeId);
+      for (const edge of graphData.edges) {
+        if (edge.source === hoveredNodeId) connectedNodeIds.add(edge.target);
+        if (edge.target === hoveredNodeId) connectedNodeIds.add(edge.source);
+      }
+    }
+
+    setNodes(nds => nds.map(node => ({
+      ...node,
+      style: {
+        ...node.style,
+        opacity: hoveredNodeId && !connectedNodeIds.has(node.id) ? 0.2 : 1
+      }
+    })));
+
+    setEdges(eds => eds.map(edge => {
+      const isConnected = hoveredNodeId && (edge.source === hoveredNodeId || edge.target === hoveredNodeId);
+      return {
+        ...edge,
+        style: {
+          ...edge.style,
+          opacity: hoveredNodeId && !isConnected ? 0.1 : 1,
+          strokeWidth: isConnected ? 5 : 3
+        }
+      };
+    }));
+  }, [hoveredNodeId, graphData.edges]);
 
   const handleProjectFilterChange = useCallback((projects) => {
     setFilteredProjects(projects);

--- a/src/components/ADRGraph/ADRGraph.js
+++ b/src/components/ADRGraph/ADRGraph.js
@@ -66,6 +66,7 @@ export default function ADRGraph() {
   const [searchTerm, setSearchTerm] = useState('');
   const [loading, setLoading] = useState(true);
   const [currentVersion, setCurrentVersion] = useState(null);
+  const [hoveredNodeId, setHoveredNodeId] = useState(null);
   const { colorMode } = useColorMode();
   const location = useLocation();
 
@@ -190,6 +191,16 @@ export default function ADRGraph() {
 
     const isDark = colorMode === 'dark';
 
+    // Compute connected node IDs for hover impact analysis
+    const connectedNodeIds = new Set();
+    if (hoveredNodeId) {
+      connectedNodeIds.add(hoveredNodeId);
+      for (const edge of filteredEdges) {
+        if (edge.source === hoveredNodeId) connectedNodeIds.add(edge.target);
+        if (edge.target === hoveredNodeId) connectedNodeIds.add(edge.source);
+      }
+    }
+
     const reactFlowNodes = filteredNodes.map((node) => {
       const { width, height } = getBubbleDimensions(node.referenceCount);
       const isHighlighted = searchTerm !== '' &&
@@ -198,6 +209,8 @@ export default function ADRGraph() {
 
       const colors = CATEGORY_COLORS[node.category] || CATEGORY_COLORS.network;
       const categoryColor = isDark ? colors.dark : colors.light;
+
+      const isDimmed = hoveredNodeId && !connectedNodeIds.has(node.id);
 
       // Build complete path with version prefix and baseUrl
       // Paths in JSON are like: /hercules_network_adr/adr002-...
@@ -235,13 +248,17 @@ export default function ADRGraph() {
           borderRadius: '50%',
           display: 'flex',
           alignItems: 'center',
-          justifyContent: 'center'
+          justifyContent: 'center',
+          opacity: isDimmed ? 0.2 : 1,
+          transition: 'opacity 0.2s ease'
         }
       };
     });
 
     const reactFlowEdges = filteredEdges.map((edge) => {
       const edgeColor = isDark ? '#6b8ec8' : '#4a7bc8';
+      const isConnectedEdge = hoveredNodeId && (edge.source === hoveredNodeId || edge.target === hoveredNodeId);
+      const isEdgeDimmed = hoveredNodeId && !isConnectedEdge;
 
       return {
         id: edge.id,
@@ -251,7 +268,9 @@ export default function ADRGraph() {
         animated: true,
         style: {
           stroke: edgeColor,
-          strokeWidth: 3
+          strokeWidth: isConnectedEdge ? 5 : 3,
+          opacity: isEdgeDimmed ? 0.1 : 1,
+          transition: 'opacity 0.2s ease, stroke-width 0.2s ease'
         },
         markerEnd: {
           type: MarkerType.ArrowClosed,
@@ -269,7 +288,7 @@ export default function ADRGraph() {
 
     setNodes(layoutedNodes);
     setEdges(layoutedEdges);
-  }, [graphData, filteredProjects, filteredCategories, searchTerm, colorMode, currentVersion, latestVersion, baseUrl]);
+  }, [graphData, filteredProjects, filteredCategories, searchTerm, colorMode, currentVersion, latestVersion, baseUrl, hoveredNodeId]);
 
   const handleProjectFilterChange = useCallback((projects) => {
     setFilteredProjects(projects);
@@ -281,6 +300,14 @@ export default function ADRGraph() {
 
   const handleSearchChange = useCallback((term) => {
     setSearchTerm(term);
+  }, []);
+
+  const onNodeMouseEnter = useCallback((_, node) => {
+    setHoveredNodeId(node.id);
+  }, []);
+
+  const onNodeMouseLeave = useCallback(() => {
+    setHoveredNodeId(null);
   }, []);
 
   if (loading) {
@@ -319,6 +346,8 @@ export default function ADRGraph() {
         edges={edges}
         onNodesChange={onNodesChange}
         onEdgesChange={onEdgesChange}
+        onNodeMouseEnter={onNodeMouseEnter}
+        onNodeMouseLeave={onNodeMouseLeave}
         nodeTypes={nodeTypes}
         fitView
         minZoom={0.1}

--- a/src/components/ADRGraph/ADRGraph.module.css
+++ b/src/components/ADRGraph/ADRGraph.module.css
@@ -111,18 +111,6 @@
   text-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
 }
 
-.referenceBadgeBubble {
-  background: rgba(255, 255, 255, 0.25);
-  backdrop-filter: blur(4px);
-  color: white;
-  font-size: 0.75rem;
-  padding: 4px 12px;
-  border-radius: 20px;
-  font-weight: 600;
-  white-space: nowrap;
-  border: 1px solid rgba(255, 255, 255, 0.3);
-}
-
 .bubbleTitle {
   font-size: 0.9rem;
   font-weight: 600;
@@ -375,13 +363,6 @@
   flex-shrink: 0;
 }
 
-.legendHint {
-  margin: 10px 0 0 0;
-  font-size: 0.7rem;
-  color: var(--ifm-color-emphasis-500);
-  font-style: italic;
-}
-
 /* Mobile Responsive */
 @media (max-width: 768px) {
   .container {
@@ -407,11 +388,6 @@
 
   .bubbleTitle {
     font-size: 0.8rem;
-  }
-
-  .referenceBadgeBubble {
-    font-size: 0.7rem;
-    padding: 3px 8px;
   }
 
   .bubbleContent {

--- a/src/components/ADRGraph/ADRGraph.module.css
+++ b/src/components/ADRGraph/ADRGraph.module.css
@@ -102,7 +102,7 @@
 }
 
 .adrNumberBubble {
-  font-size: 2.75rem;
+  font-size: 2rem;
   font-weight: 800;
   letter-spacing: -2px;
   font-family: var(--ifm-font-family-base);

--- a/src/components/ADRGraph/ADRGraph.module.css
+++ b/src/components/ADRGraph/ADRGraph.module.css
@@ -52,7 +52,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
   cursor: pointer;
   position: relative;
   overflow: visible;

--- a/src/components/ADRGraph/CustomNode.js
+++ b/src/components/ADRGraph/CustomNode.js
@@ -16,7 +16,7 @@ function CustomNode({ data }) {
       <a href={path} className={styles.bubbleContent} title={title}>
         <div className={styles.bubbleCenter}>
           <div className={styles.adrNumberBubble}>
-            {number}
+            ADR {number}
           </div>
           {referenceCount > 0 && (
             <div className={styles.referenceBadgeBubble}>

--- a/src/components/ADRGraph/CustomNode.js
+++ b/src/components/ADRGraph/CustomNode.js
@@ -3,7 +3,7 @@ import { Handle, Position } from 'reactflow';
 import styles from './ADRGraph.module.css';
 
 function CustomNode({ data }) {
-  const { number, title, category, tags, referenceCount, path, isHighlighted } = data;
+  const { number, title, category, path, isHighlighted } = data;
 
   const categoryColor = category === 'network' ? '#386FB3' : '#C4D042';
 
@@ -18,11 +18,6 @@ function CustomNode({ data }) {
           <div className={styles.adrNumberBubble}>
             ADR {number}
           </div>
-          {referenceCount > 0 && (
-            <div className={styles.referenceBadgeBubble}>
-              {referenceCount}
-            </div>
-          )}
         </div>
         <div className={styles.bubbleTitle}>
           {title}

--- a/src/components/ADRGraph/GraphControls.js
+++ b/src/components/ADRGraph/GraphControls.js
@@ -152,7 +152,6 @@ export default function GraphControls({
               <span className={styles.legendDot} style={{ background: '#9B59B6' }} />
               <span>Orion</span>
             </div>
-            <p className={styles.legendHint}>Larger nodes = more references</p>
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary

- Hovering over a node dims unrelated nodes (opacity 0.2) and edges (opacity 0.1)
- Connected edges get thicker (strokeWidth 5) for emphasis
- Smooth 0.2s transitions for all opacity changes

Closes #65

## Test plan

- [x] `npm run build` succeeds
- [ ] Manually verify: hover over a node in the ADR Graph and confirm connected nodes/edges stay visible while unrelated ones dim