### PR TITLE
fix: ADR Graph shows wrong version, new ADRs missing in Upcoming

### DIFF
--- a/plugins/docusaurus-adr-graph-plugin/adrParser.js
+++ b/plugins/docusaurus-adr-graph-plugin/adrParser.js
@@ -157,49 +157,55 @@ function extractADRSlug(filePath) {
 }
 
 /**
- * Build graph data structure from ADR files
+ * Parse ADR files from a directory into a Map keyed by ADR id.
  */
-function buildGraphData(docsDir, versionPrefix = '/docs') {
-  const adrFiles = findADRFiles(docsDir);
-  const nodes = [];
-  const edges = [];
-  const referenceCountMap = new Map();
-
-  for (const filePath of adrFiles) {
+function parseADRsFromDir(dir, versionPrefix) {
+  const adrMap = new Map();
+  for (const filePath of findADRFiles(dir)) {
     const adr = parseADRFile(filePath, versionPrefix);
     if (adr) {
-      nodes.push({
-        id: adr.id,
-        number: adr.number,
-        title: adr.title,
-        project: adr.project,
-        category: adr.category,
-        tags: adr.tags,
-        path: adr.path,
-        referenceCount: 0
-      });
-      referenceCountMap.set(adr.id, adr.references);
+      adrMap.set(adr.id, adr);
     }
   }
+  return adrMap;
+}
 
+/**
+ * Build edges from a reference map and return edges + incoming reference counts.
+ */
+function buildEdges(referenceCountMap, nodeIds) {
+  const edges = [];
   const incomingReferences = new Map();
 
   for (const [sourceId, targetIds] of referenceCountMap.entries()) {
     for (const targetNumber of targetIds) {
       const targetId = `adr${targetNumber}`;
-
-      // Only create edge if target exists
-      if (nodes.some(n => n.id === targetId)) {
-        edges.push({
-          id: `${sourceId}-${targetId}`,
-          source: sourceId,
-          target: targetId,
-          type: 'smoothstep'
-        });
+      if (nodeIds.has(targetId)) {
+        edges.push({ id: `${sourceId}-${targetId}`, source: sourceId, target: targetId, type: 'smoothstep' });
         incomingReferences.set(targetId, (incomingReferences.get(targetId) || 0) + 1);
       }
     }
   }
+
+  return { edges, incomingReferences };
+}
+
+/**
+ * Build graph data structure from ADR files in the given directory.
+ */
+function buildGraphData(docsDir, versionPrefix = '/docs') {
+  const adrMap = parseADRsFromDir(docsDir, versionPrefix);
+
+  const referenceCountMap = new Map();
+  const nodes = [];
+
+  for (const adr of adrMap.values()) {
+    nodes.push({ id: adr.id, number: adr.number, title: adr.title, project: adr.project, category: adr.category, tags: adr.tags, path: adr.path, referenceCount: 0 });
+    referenceCountMap.set(adr.id, adr.references);
+  }
+
+  const nodeIds = new Set(nodes.map(n => n.id));
+  const { edges, incomingReferences } = buildEdges(referenceCountMap, nodeIds);
 
   for (const node of nodes) {
     node.referenceCount = incomingReferences.get(node.id) || 0;

--- a/plugins/docusaurus-adr-graph-plugin/index.js
+++ b/plugins/docusaurus-adr-graph-plugin/index.js
@@ -18,7 +18,7 @@ module.exports = function (context) {
       );
       console.log(`  Upcoming: ${currentData.nodes.length} nodes, ${currentData.edges.length} edges`);
 
-      // Build for each versioned docs - store paths without version prefix
+      // Build for each versioned docs - only ADRs frozen in that release snapshot
       const versions = getVersions(siteDir);
       for (const version of versions) {
         const versionedDocsDir = path.join(siteDir, 'versioned_docs', `version-${version}`);
@@ -49,7 +49,7 @@ module.exports = function (context) {
         JSON.stringify(currentData, null, 2)
       );
 
-      // Build for each versioned docs - store paths without version prefix
+      // Build for each versioned docs - only ADRs frozen in that release snapshot
       const versions = getVersions(siteDir);
       for (const version of versions) {
         const versionedDocsDir = path.join(siteDir, 'versioned_docs', `version-${version}`);

--- a/src/components/ADRGraph/ADRGraph.js
+++ b/src/components/ADRGraph/ADRGraph.js
@@ -14,7 +14,7 @@ import styles from './ADRGraph.module.css';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import { useColorMode } from '@docusaurus/theme-common';
 import { useLocation } from '@docusaurus/router';
-import { useVersions } from '@docusaurus/plugin-content-docs/client';
+import { useVersions, useDocsPreferredVersion } from '@docusaurus/plugin-content-docs/client';
 
 const nodeTypes = {
   custom: CustomNode
@@ -72,61 +72,28 @@ export default function ADRGraph() {
 
   const baseUrl = useBaseUrl('/');
 
-  // Get versions from Docusaurus plugin (works in both dev and production)
+  // Get versions and user preference from Docusaurus plugin
   const allVersions = useVersions('default');
-  // Filter to only released versions (exclude "current" which is upcoming/unreleased)
-  const availableVersions = allVersions
-    .filter(v => v.name !== 'current')
-    .map(v => v.name);
-  // Get the latest released version (isLast=true means latest released version)
   const latestReleasedVersion = allVersions.find(v => v.isLast);
-  const latestVersion = latestReleasedVersion ? latestReleasedVersion.name : (availableVersions.length > 0 ? availableVersions[0] : null);
+  const latestVersion = latestReleasedVersion ? latestReleasedVersion.name : null;
 
-  // Get current version from localStorage or default to latest
-  const getVersion = useCallback(() => {
-    // Check URL parameter first (e.g., /adr-graph?version=2025-12)
+  // useDocsPreferredVersion is reactive: updates automatically when the user
+  // changes the version in the navbar, no polling needed.
+  const { preferredVersion } = useDocsPreferredVersion('default');
+
+  // Determine which version's graph data to load.
+  // Priority: URL param > Docusaurus preferred version > 'current' (Upcoming)
+  useEffect(() => {
     const params = new URLSearchParams(location.search);
     const versionParam = params.get('version');
     if (versionParam) {
-      return versionParam;
+      setCurrentVersion(versionParam);
+      return;
     }
-
-    // Try to get version from localStorage (set by Docusaurus version switcher)
-    try {
-      const preferredVersion = localStorage.getItem('docs-preferred-version-default');
-      if (preferredVersion) {
-        return preferredVersion;
-      }
-    } catch (e) {
-      // localStorage might not be available
-    }
-
-    // Default to the latest released version (2025-12), same as Docusaurus navbar
-    return latestVersion || '2025-12';
-  }, [location.search, latestVersion]);
-
-  // Initialize version
-  useEffect(() => {
-    setCurrentVersion(getVersion());
-  }, [getVersion]);
-
-  // Listen for storage changes (when version is changed in navbar)
-  useEffect(() => {
-    // Poll for localStorage changes (storage event doesn't fire in same tab)
-    const pollInterval = setInterval(() => {
-      const newVersion = getVersion();
-      setCurrentVersion(prev => {
-        if (prev !== newVersion) {
-          return newVersion;
-        }
-        return prev;
-      });
-    }, 500);
-
-    return () => {
-      clearInterval(pollInterval);
-    };
-  }, [getVersion]);
+    // preferredVersion is null on first render (SSR-safe), then resolves to the
+    // stored value. Default to 'current' (Upcoming) so new ADRs are always visible.
+    setCurrentVersion(preferredVersion ? preferredVersion.name : 'current');
+  }, [location.search, preferredVersion]);
 
   // Load graph data based on docs version
   useEffect(() => {


### PR DESCRIPTION
Fixes #71

## Problem

When no Docusaurus version preference is stored (fresh browser / first visit), `ADRGraph.js` fell back to the latest *released* version (`2026-3`) instead of `current` (Upcoming). As a result, newly merged ADRs like 103, 104, 105 were invisible even though the navbar showed "Upcoming".

The previous version sync polled `localStorage` every 500 ms — fragile and delayed.

## Changes

**`src/components/ADRGraph/ADRGraph.js`**
- Replace manual `localStorage` polling with the reactive `useDocsPreferredVersion` hook → graph updates instantly when the user switches versions in the navbar
- Default to `'current'` (Upcoming) when no preference is stored → new ADRs are always visible out of the box

**`plugins/docusaurus-adr-graph-plugin/adrParser.js`**
- Extract `parseADRsFromDir()` and `buildEdges()` to reduce cognitive complexity

**`plugins/docusaurus-adr-graph-plugin/index.js`**
- Align comments with actual behavior

## Test plan

- [ ] Fresh browser (no localStorage) → ADR Graph defaults to Upcoming, all ADRs visible
- [ ] Switch navbar to `2026-3` → graph shows only that release's ADRs
- [ ] Switch back to Upcoming → graph updates immediately without page reload
- [ ] Merge a new ADR to `main` → appears in Upcoming graph after next deploy