### PR TITLE
chore(deps): bump actions/setup-node from 4 to 6

### DIFF
--- a/.github/workflows/lint-adrs.yaml
+++ b/.github/workflows/lint-adrs.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm


### PR DESCRIPTION
Bumps `actions/setup-node` from v4 to v6 in `.github/workflows/lint-adrs.yaml`.

Closes #97 — resolves the Dependabot PR that couldn't be merged via API due to missing `workflow` scope.